### PR TITLE
fix: 钉钉 API 更改导致本科生课程无法获取

### DIFF
--- a/pkg/zjuservice/ugrsical/ugrsical.go
+++ b/pkg/zjuservice/ugrsical/ugrsical.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	kAppServiceLoginUrl           = "https://zjuam.zju.edu.cn/cas/login?service=http%3A%2F%2Fappservice.zju.edu.cn%2F"
-	kAppServiceGetWeekClassInfo   = "http://appservice.zju.edu.cn/zju-smartcampus/zdydjw/api/kbdy_cxXsZKbxx"
+	kAppServiceGetWeekClassInfo   = "http://appservice.zju.edu.cn/zju-smartcampus/zdydjw/api/kbdy_cxDqXnxxq"
 	kAppServiceGetExamOutlineInfo = "http://appservice.zju.edu.cn/zju-smartcampus/zdydjw/api/kkqk_cxXsksxx"
 	kAppServiceGetClassScore      = "http://appservice.zju.edu.cn/zju-smartcampus/zdydjw/api/kkqk_cxXscjxx"
 )


### PR DESCRIPTION
已更改为正确的 API（通过访问 http://appservice.zju.edu.cn/zdjw/grkb 获取）